### PR TITLE
Implement commands module

### DIFF
--- a/autocomplete_ignite
+++ b/autocomplete_ignite
@@ -17,10 +17,7 @@ function _ignite_complete {
         }
         . "$_ignite_script_path"
 
-        for v in "${VALID_OPERATIONS[@]}"; do
-            v=($v)
-            COMPREPLY+=("${v[0]}")
-        done
+        COMPREPLY+=(`_commands_get`)
     fi
 }
 

--- a/ignite
+++ b/ignite
@@ -14,15 +14,12 @@ _ignite_version=$(cat $IGNITE_INSTALLATION/VERSION)
 
 import_module print
 import_module colors
+import_module commands
 
 function usage {
-    if [[ "${#VALID_OPERATIONS[@]}" -eq 0 ]]; then
-        echo "No operations defined in ignite script" >&2
-        exit 1
-    fi
     echo "Usage:"
-    for op in "${VALID_OPERATIONS[@]}"; do
-        echo -e "\t$0 $_ignite_script_name $op"
+    for op in `_commands_get`; do
+        echo -e "\t$(basename $0) $_ignite_script_name $op"
     done
 }
 
@@ -35,11 +32,11 @@ function main {
     shift
 
     # See if implementation-defined operation
-    for op in "${VALID_OPERATIONS[@]}"; do
-        op=(${op[@]})
-        if [[ "$command" == "${op[0]}" ]]; then
+    for op in `_commands_get`; do
+        if [[ "$command" == "$op" ]]; then
+            SOURCE_PATH=${SOURCE_PATH:-"."}
             if [ ! -d "$SOURCE_PATH" ]; then
-                echo "$SOURCE_PATH does not exist" >&2
+                echo "Source path '$SOURCE_PATH' does not exist" >&2
                 exit 1
             fi
             cd $SOURCE_PATH
@@ -50,14 +47,12 @@ function main {
     done
     # Didnt hit a registered operation
     case "$command" in
-        help)
+        --help)
             usage
-            exit $?
             ;;
         *)
             echo "Unknown command '$command'"
             usage
-            exit 1
             ;;
     esac
 }
@@ -83,9 +78,6 @@ _ignite_script_name="$1"
 shift
 
 . "$_ignite_script_path"
-
-VALID_OPERATIONS=${VALID_OPERATIONS:-()}
-SOURCE_PATH=${SOURCE_PATH:-"."}
 
 # Execute main function
 main "$@"

--- a/modules/commands
+++ b/modules/commands
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-function op_commands {
+function _commands_get {
     typeset -f | grep -E '^op_.+ ()$' | sed 's/ ()//g' | sed 's/op_//g'
+}
+
+function op_commands {
+    _commands_get
+
 }

--- a/modules/commands
+++ b/modules/commands
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+function op_commands {
+    typeset -f | grep -E '^op_.+ ()$' | sed 's/ ()//g' | sed 's/op_//g'
+}

--- a/modules/reactor
+++ b/modules/reactor
@@ -33,6 +33,5 @@ function initialize_reactor {
             __reactor_pipeline $task
         }"
 
-        VALID_OPERATIONS+=("$task")
     done
 }

--- a/samples/ignite_sample
+++ b/samples/ignite_sample
@@ -7,13 +7,6 @@ LATEST_VERSION='1.0.0-SNAPSHOT'
 
 VERSION=${VERSION:-$LATEST_VERSION}
 
-
-VALID_OPERATIONS=(
-    "info"
-    "install"
-)
-
-
 function op_info {
     echo -e "${GREEN_FG}Hi I am $APP_NAME@$VERSION${CLRT}"
 }


### PR DESCRIPTION
Implement module that takes care of command resolution and viewing. This will supersede the old, manual `VALID_OPERATIONS` registering strategy. Any function defined with the `op_` prefix will be picked up as a valid command.

Along with this, improvements have been made on the main executor side to use this new logic.