### PR TITLE
Parse arrays as arguments

### DIFF
--- a/ignite_setup
+++ b/ignite_setup
@@ -7,7 +7,7 @@ arguments_config=(
 )
 
 function op_install {
-    arguments_parse "$@"
+    arguments_parse arguments_config "$@"
     if [ $link_dir ]; then
         _symlink_dir="$link_dir"
     else

--- a/modules/arguments
+++ b/modules/arguments
@@ -5,18 +5,22 @@ import_module print
 # 1=switch (string)
 # 2=output_variable_name (string)
 # 3=shifter (int)
-arguments_config=()
+__arguments_config=()
 
 _arguments_allow_switchless=false
 
 function arguments_parse {
-    if [[ ${#arguments_config[@]} -eq 0 ]]; then
-        echo "fatal: arguments_config not implemented" >&2
+    local arg_var=$1
+    shift
+    eval "local __arguments_config=(\"\${$arg_var[@]}\")"
+
+    if [[ ${#__arguments_config[@]} -eq 0 ]]; then
+        echo "fatal: $arg_var not set" >&2
         return 8
     fi
     while [[ $# -gt 0 ]]; do
         _found=false
-        for arg in "${arguments_config[@]}"; do
+        for arg in "${__arguments_config[@]}"; do
             a=($arg)
             switch="${a[0]}"
             output_var="${a[1]}"
@@ -82,9 +86,13 @@ function __error_invalid {
 }
 
 function arguments_print {
+    local arg_var=$1
+    shift
+    eval "local __arguments_config=(\"\${$arg_var[@]}\")"
+
     local buffer=""
     local mandatory_args=""
-    for arg in "${arguments_config[@]}"; do
+    for arg in "${__arguments_config[@]}"; do
         a=($arg)
         switch="${a[0]}"
         output_var="${a[1]}"

--- a/modules/arguments
+++ b/modules/arguments
@@ -1,18 +1,21 @@
 #!/bin/bash
 
 import_module print
+import_module define
 
 # 1=switch (string)
 # 2=output_variable_name (string)
 # 3=shifter (int)
-__arguments_config=()
+# 4=is_mandatory (boolean) [optional]
+# 5=description (string) [optional]
+arguments_config=()
 
 _arguments_allow_switchless=false
 
 function arguments_parse {
-    local arg_var=$1
+    local __arguments_config=
+    define_list __arguments_config $1
     shift
-    eval "local __arguments_config=(\"\${$arg_var[@]}\")"
 
     if [[ ${#__arguments_config[@]} -eq 0 ]]; then
         echo "fatal: $arg_var not set" >&2
@@ -86,9 +89,9 @@ function __error_invalid {
 }
 
 function arguments_print {
-    local arg_var=$1
+    local __arguments_config=
+    define_list __arguments_config $1
     shift
-    eval "local __arguments_config=(\"\${$arg_var[@]}\")"
 
     local buffer=""
     local mandatory_args=""

--- a/modules/define
+++ b/modules/define
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+import_module print
+
+function define_list {
+    dest_var="$1"
+    shift
+
+    eval "$dest_var=()"
+    for i in $@; do
+        source_var="$i"
+        eval "$dest_var+=(\"\${$source_var[@]}\")"
+    done
+}

--- a/modules/ssh
+++ b/modules/ssh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
 import_module print
+import_module define
 
-_ssh_push_files=()
 function ssh_push {
-    local _ssh_hosts=("$@")
+    local _ssh_push_files
+    define_list _ssh_push_files $1
+    local _ssh_hosts
+    define_list _ssh_hosts $2
+    shift 2
+
     if [[ ${#_ssh_hosts[@]} -eq 0 ]]; then
         print_error "No hosts to push to"
         return 1
@@ -28,14 +33,11 @@ function ssh_push {
 
 _ssh_execute_continue_on_error=false
 function ssh_execute {
-    if [[ $# -lt 1 ]]; then
-        print_error "Nothing to run..." >&2
-        return 1
-    fi
     local _ssh_command="$1"
-    shift
+    local _ssh_hosts
+    define_list _ssh_hosts $2
+    shift 2
 
-    local _ssh_hosts=("$@")
     if [[ ${#_ssh_hosts[@]} -eq 0 ]]; then
         print_error "No hosts to remote execute on"
         return 1


### PR DESCRIPTION
Using a new module define, arrays can be parsed in as arguments even
in the case where more than one array needs to be a argument. The define
module takes the reference to the array and copies the data to
localised variables.